### PR TITLE
修正传环境变量运行时未获取record_id的问题

### DIFF
--- a/ddns.py
+++ b/ddns.py
@@ -25,11 +25,9 @@ def read_config_to_env():
         except IndexError:
             logging.error('config error')
             exit()
-        if not os.getenv('RECORD_ID'):
-            record_id = get_record_id(os.getenv('DOMAIN'), os.getenv('SUB_DOMAIN'))
-            if not record_id:
-                record_id = get_record_id(os.getenv('DOMAIN'), os.getenv('SUB_DOMAIN'))
-            os.environ['RECORD_ID'] = record_id
+    if not os.getenv('RECORD_ID'):
+        record_id = get_record_id(os.getenv('DOMAIN'), os.getenv('SUB_DOMAIN'))
+        os.environ['RECORD_ID'] = record_id
 
 
 def check_config():


### PR DESCRIPTION
修正一个逻辑错误：传环境变量运行时，不会检查RECORD_ID变量是否设置，导致RECORD_ID为None